### PR TITLE
refactor(query): rename methos and class, and major querys in repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,7 @@ sonarqube {
                     **/*Application**,
                     **/ApiUtil.class,
                     **/model/**
+                    **/entity/**
     """
     }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,12 +11,12 @@ servers:
     description: Servidor de producción
 
 paths:
-  /prices/search:
+  /prices:
     post:
       tags:
         - PricingController
-      operationId: getFinalPrice
-      summary: Consultar precio aplicable
+      operationId: getApplicablePrice
+      summary: Consultar precio aplicable por producto, marca y fecha
       requestBody:
         required: true
         content:
@@ -33,11 +33,11 @@ paths:
         '404':
           description: No se encontró precio aplicable
 
-  /prices/{productId}/product:
+  /products/{productId}/prices:
     get:
       tags:
         - PricingController
-      operationId: getPriceForProduct
+      operationId: getAllPricesByProductId
       parameters:
         - in: path
           name: productId
@@ -46,7 +46,7 @@ paths:
             type: integer
             default: 35456
             example: 35456
-      summary: Obtener todos los precios por un producto
+      summary: Obtener todos los precios por producto
       responses:
         '200':
           description: Lista de precios
@@ -61,8 +61,8 @@ paths:
     get:
       tags:
         - PricingController
-      operationId: getPriceForIdentifier
-      summary: Obtener el precio del producto por su id
+      operationId: getPriceById
+      summary: Obtener el precio del producto por ID
       parameters:
         - in: path
           name: id
@@ -92,14 +92,19 @@ components:
         applicationDate:
           type: string
           format: date-time
+          required: true
+          description: Fecha y hora de aplicación
           example: "2020-06-14T16:00:00.000Z"
           default: "2020-06-14T16:00:00.000Z"
         productId:
           type: integer
           example: 35456
           default: 35456
+          required: true
+          description: Identificador del producto
         brandId:
           type: integer
+          description: Identificador de la cadena (marca)
           example: 1
           default: 1
     PriceResponse:

--- a/src/main/java/com/ecommerce/pricing/application/service/PriceServiceAdapterImpl.java
+++ b/src/main/java/com/ecommerce/pricing/application/service/PriceServiceAdapterImpl.java
@@ -2,9 +2,9 @@ package com.ecommerce.pricing.application.service;
 
 import com.ecommerce.pricing.domain.mappers.PriceMapper;
 import com.ecommerce.pricing.domain.model.PriceResponse;
-import com.ecommerce.pricing.domain.ports.in.GetAllPriceForProductUseCase;
-import com.ecommerce.pricing.domain.ports.in.GetPriceForIdentifierUseCase;
-import com.ecommerce.pricing.domain.ports.in.GetPriceUseCase;
+import com.ecommerce.pricing.domain.ports.in.GetAllPricesByProductIdUseCase;
+import com.ecommerce.pricing.domain.ports.in.GetPriceByIdUseCase;
+import com.ecommerce.pricing.domain.ports.in.GetApplicablePriceUseCase;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,22 +15,22 @@ import reactor.core.publisher.Mono;
 @Service
 public class PriceServiceAdapterImpl implements PriceServiceAdapter {
 
-  private final GetAllPriceForProductUseCase getAllPriceForProductUseCase;
-  private final GetPriceForIdentifierUseCase getPriceForIdentifierUseCase;
-  private final GetPriceUseCase getPriceUseCase;
+  private final GetAllPricesByProductIdUseCase getAllPricesByProductIdUseCase;
+  private final GetPriceByIdUseCase getPriceByIdUseCase;
+  private final GetApplicablePriceUseCase getApplicablePriceUseCase;
 
   @Override
   public Flux<PriceResponse> getAllPriceByProduct(Long productId) {
-    return getAllPriceForProductUseCase.getAllPriceByProduct(productId).map(PriceMapper.toApi);
+    return getAllPricesByProductIdUseCase.getAllPriceByProduct(productId).map(PriceMapper.toApi);
   }
 
   @Override
   public Mono<PriceResponse> getPriceForIdentifier(Long id) {
-    return getPriceForIdentifierUseCase.getPriceForIdentifier(id).map(PriceMapper.toApi);
+    return getPriceByIdUseCase.getPriceForIdentifier(id).map(PriceMapper.toApi);
   }
 
   @Override
   public Mono<PriceResponse> getPriceProduct(Long productId, Integer brandId, LocalDateTime date) {
-    return getPriceUseCase.getPriceProduct(productId, brandId, date).map(PriceMapper.toApi);
+    return getApplicablePriceUseCase.getPriceProduct(productId, brandId, date).map(PriceMapper.toApi);
   }
 }

--- a/src/main/java/com/ecommerce/pricing/application/usecase/GetAllPricesByProductIdUseCaseImpl.java
+++ b/src/main/java/com/ecommerce/pricing/application/usecase/GetAllPricesByProductIdUseCaseImpl.java
@@ -1,22 +1,22 @@
 package com.ecommerce.pricing.application.usecase;
 
 import com.ecommerce.pricing.domain.model.Price;
-import com.ecommerce.pricing.domain.ports.in.GetPriceForIdentifierUseCase;
+import com.ecommerce.pricing.domain.ports.in.GetAllPricesByProductIdUseCase;
 import com.ecommerce.pricing.domain.ports.out.PriceRepositoryPort;
 import com.ecommerce.pricing.infrastructure.config.TimedLog;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
 
 @AllArgsConstructor
 @Service
-public class GetPriceForIdentifierUseCaseImpl implements GetPriceForIdentifierUseCase {
+public class GetAllPricesByProductIdUseCaseImpl implements GetAllPricesByProductIdUseCase {
 
   private final PriceRepositoryPort priceRepositoryPort;
 
   @TimedLog
   @Override
-  public Mono<Price> getPriceForIdentifier(Long id) {
-    return priceRepositoryPort.getPriceById(id);
+  public Flux<Price> getAllPriceByProduct(Long productId) {
+    return priceRepositoryPort.findAllPricesByProductId(productId);
   }
 }

--- a/src/main/java/com/ecommerce/pricing/application/usecase/GetApplicablePriceUseCaseImpl.java
+++ b/src/main/java/com/ecommerce/pricing/application/usecase/GetApplicablePriceUseCaseImpl.java
@@ -1,7 +1,7 @@
 package com.ecommerce.pricing.application.usecase;
 
 import com.ecommerce.pricing.domain.model.Price;
-import com.ecommerce.pricing.domain.ports.in.GetPriceUseCase;
+import com.ecommerce.pricing.domain.ports.in.GetApplicablePriceUseCase;
 import com.ecommerce.pricing.domain.ports.out.PriceRepositoryPort;
 import com.ecommerce.pricing.infrastructure.config.TimedLog;
 import java.time.LocalDateTime;
@@ -11,7 +11,7 @@ import reactor.core.publisher.Mono;
 
 @Service
 @AllArgsConstructor
-public class GetPriceUseCaseImpl implements GetPriceUseCase {
+public class GetApplicablePriceUseCaseImpl implements GetApplicablePriceUseCase {
 
   private final PriceRepositoryPort priceRepositoryPort;
 
@@ -19,9 +19,6 @@ public class GetPriceUseCaseImpl implements GetPriceUseCase {
   @Override
   public Mono<Price> getPriceProduct(Long productId, Integer brandId,
       LocalDateTime applicationDate) {
-    return priceRepositoryPort.getPricesByDate(productId, brandId, applicationDate)
-        .sort((p1, p2) -> Integer.compare(p2.getPriority(),
-            p1.getPriority()))
-        .next();
+    return priceRepositoryPort.findApplicablePrices(productId, brandId, applicationDate);
   }
 }

--- a/src/main/java/com/ecommerce/pricing/application/usecase/GetPriceByIdUseCaseImpl.java
+++ b/src/main/java/com/ecommerce/pricing/application/usecase/GetPriceByIdUseCaseImpl.java
@@ -1,22 +1,22 @@
 package com.ecommerce.pricing.application.usecase;
 
 import com.ecommerce.pricing.domain.model.Price;
-import com.ecommerce.pricing.domain.ports.in.GetAllPriceForProductUseCase;
+import com.ecommerce.pricing.domain.ports.in.GetPriceByIdUseCase;
 import com.ecommerce.pricing.domain.ports.out.PriceRepositoryPort;
 import com.ecommerce.pricing.infrastructure.config.TimedLog;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @AllArgsConstructor
 @Service
-public class GetAllPriceForProductUseCaseImpl implements GetAllPriceForProductUseCase {
+public class GetPriceByIdUseCaseImpl implements GetPriceByIdUseCase {
 
   private final PriceRepositoryPort priceRepositoryPort;
 
   @TimedLog
   @Override
-  public Flux<Price> getAllPriceByProduct(Long productId) {
-    return priceRepositoryPort.getAllPricesByProductId(productId);
+  public Mono<Price> getPriceForIdentifier(Long id) {
+    return priceRepositoryPort.findPriceById(id);
   }
 }

--- a/src/main/java/com/ecommerce/pricing/domain/ports/in/GetAllPricesByProductIdUseCase.java
+++ b/src/main/java/com/ecommerce/pricing/domain/ports/in/GetAllPricesByProductIdUseCase.java
@@ -3,7 +3,7 @@ package com.ecommerce.pricing.domain.ports.in;
 import com.ecommerce.pricing.domain.model.Price;
 import reactor.core.publisher.Flux;
 
-public interface GetAllPriceForProductUseCase {
+public interface GetAllPricesByProductIdUseCase {
 
   /**
    *Obtener los precios de un producto.

--- a/src/main/java/com/ecommerce/pricing/domain/ports/in/GetApplicablePriceUseCase.java
+++ b/src/main/java/com/ecommerce/pricing/domain/ports/in/GetApplicablePriceUseCase.java
@@ -4,7 +4,7 @@ import com.ecommerce.pricing.domain.model.Price;
 import java.time.LocalDateTime;
 import reactor.core.publisher.Mono;
 
-public interface GetPriceUseCase {
+public interface GetApplicablePriceUseCase {
 
   /**
    * Obetner el precio de un producto por determinada fecha y validar su prioridad.

--- a/src/main/java/com/ecommerce/pricing/domain/ports/in/GetPriceByIdUseCase.java
+++ b/src/main/java/com/ecommerce/pricing/domain/ports/in/GetPriceByIdUseCase.java
@@ -3,7 +3,7 @@ package com.ecommerce.pricing.domain.ports.in;
 import com.ecommerce.pricing.domain.model.Price;
 import reactor.core.publisher.Mono;
 
-public interface GetPriceForIdentifierUseCase {
+public interface GetPriceByIdUseCase {
 
   /**
    *

--- a/src/main/java/com/ecommerce/pricing/domain/ports/out/PriceRepositoryPort.java
+++ b/src/main/java/com/ecommerce/pricing/domain/ports/out/PriceRepositoryPort.java
@@ -5,40 +5,42 @@ import java.time.LocalDateTime;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+/**
+ * Service interface for querying product pricing information.
+ */
 public interface PriceRepositoryPort {
 
   /**
-   * Obetner el precio de un producto por determinada fecha y validar su prioridad.
+   * Retrieve the applicable price for a given product, brand, and date.
+   * Applies priority rules to select the most relevant price.
    *
-   * @param productId
-   * @param brandId
-   * @param date
-   * @return Price
+   * @param productId       the ID of the product
+   * @param brandId         the ID of the brand
+   * @param applicationDate the date for which the price is requested
+   * @return a Mono of applicable prices, ordered by priority
    */
-  Flux<Price> getPricesByDate(Long productId, Integer brandId, LocalDateTime date);
+  Mono<Price> findApplicablePrices(Long productId, Integer brandId, LocalDateTime applicationDate);
 
   /**
+   * Retrieve a price by its unique identifier.
    *
-   * Obtener el precip por su identificador.
-   *
-   * @param id
-   * @return Price
+   * @param id the ID of the price
+   * @return a Mono containing the price if found
    */
-  Mono<Price> getPriceById(Long id);
+  Mono<Price> findPriceById(Long id);
 
   /**
+   * Count the total number of price records.
    *
-   * Obtener el nuemero de registros.
-   *
-   * @return Long
+   * @return a Mono with the total number of records
    */
-  Mono<Long> selectCount();
+  Mono<Long> countPrices();
 
   /**
-   * Obtener los precios de un producto.
+   * Retrieve all prices associated with a given product ID.
    *
-   * @param productId
-   * @return ListPrices
+   * @param productId the ID of the product
+   * @return a Flux containing all price entries for the specified product
    */
-  Flux<Price> getAllPricesByProductId(Long productId);
+  Flux<Price> findAllPricesByProductId(Long productId);
 }

--- a/src/main/java/com/ecommerce/pricing/infrastructure/config/VerifyDatabaseComponent.java
+++ b/src/main/java/com/ecommerce/pricing/infrastructure/config/VerifyDatabaseComponent.java
@@ -13,10 +13,10 @@ public class VerifyDatabaseComponent {
   @Bean
   public CommandLineRunner verifyDatabase(PriceRepositoryAdapter port) {
     return args -> {
-      long count = port.selectCount().block();
+      long count = port.countPrices().block();
       log.info(">>> PRICES table has {} rows.", count);
       port
-          .getAllPricesByProductId(35455L)
+          .findAllPricesByProductId(35455L)
           .toIterable()
           .forEach(
               p -> System.out.println("Price loaded: " + p.getProductId() + " -> " + p.getPrice()));

--- a/src/main/java/com/ecommerce/pricing/infrastructure/db/repository/PriceRepository.java
+++ b/src/main/java/com/ecommerce/pricing/infrastructure/db/repository/PriceRepository.java
@@ -24,7 +24,7 @@ public interface PriceRepository extends CrudRepository<PriceEntity, Long> {
       @Param("applicationDate") LocalDateTime applicationDate);
 
   @Query("SELECT p FROM PriceEntity p WHERE p.productId = :productId ORDER BY p.startDate DESC")
-  List<PriceEntity> findPrecesByProductId(Long productId);
+  List<PriceEntity> findPrecesByProductId(@Param("productId") Long productId);
 
   @Query("SELECT p FROM PriceEntity p WHERE p.id = :id")
   PriceEntity findPriceById(@Param("id") Long id);

--- a/src/main/java/com/ecommerce/pricing/infrastructure/db/repository/PriceRepositoryAdapter.java
+++ b/src/main/java/com/ecommerce/pricing/infrastructure/db/repository/PriceRepositoryAdapter.java
@@ -4,7 +4,6 @@ import com.ecommerce.pricing.domain.mappers.PriceMapper;
 import com.ecommerce.pricing.domain.model.Price;
 import com.ecommerce.pricing.domain.ports.out.PriceRepositoryPort;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -17,24 +16,24 @@ public class PriceRepositoryAdapter implements PriceRepositoryPort {
   private PriceRepository repository;
 
   @Override
-  public Flux<Price> getPricesByDate(Long productId, Integer brandId, LocalDateTime date) {
-    return Flux.fromIterable(List.of(repository.findApplicablePrice(productId, brandId, date)))
+  public Mono<Price> findApplicablePrices(Long productId, Integer brandId, LocalDateTime applicationDate) {
+    return Mono.just(repository.findApplicablePrice(productId, brandId, applicationDate))
         .map(PriceMapper.toDomain);
   }
 
   @Override
-  public Mono<Price> getPriceById(Long id) {
+  public Mono<Price> findPriceById(Long id) {
     return Mono.just(repository.findPriceById(id))
         .map(PriceMapper.toDomain);
   }
 
   @Override
-  public Mono<Long> selectCount() {
+  public Mono<Long> countPrices() {
     return Mono.just(repository.count());
   }
 
   @Override
-  public Flux<Price> getAllPricesByProductId(Long productId) {
+  public Flux<Price> findAllPricesByProductId(Long productId) {
     return Flux.fromIterable(repository.findPrecesByProductId(productId)).map(PriceMapper.toDomain);
   }
 }

--- a/src/test/java/com/ecommerce/pricing/application/usecase/GetApplicablePriceUseCaseTest.java
+++ b/src/test/java/com/ecommerce/pricing/application/usecase/GetApplicablePriceUseCaseTest.java
@@ -14,18 +14,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 @ExtendWith(MockitoExtension.class)
-class GetPriceUseCaseTest {
+class GetApplicablePriceUseCaseTest {
 
   @Mock
   private PriceRepositoryPort priceRepository;
 
   @InjectMocks
-  private GetPriceUseCaseImpl getPriceUseCase;
+  private GetApplicablePriceUseCaseImpl getPriceUseCase;
 
   private static final Long PRODUCT_ID = 35455L;
   private static final Integer BRAND = 1;
@@ -37,8 +36,8 @@ class GetPriceUseCaseTest {
 
     LocalDateTime date = LocalDateTime.of(2020, 6, 14, 10, 0, 0);
 
-    when(priceRepository.getPricesByDate(PRODUCT_ID, BRAND, date))
-        .thenReturn(Flux.fromIterable(mapper.getPricesByDate()));
+    when(priceRepository.findApplicablePrices(PRODUCT_ID, BRAND, date))
+        .thenReturn(Mono.just(mapper.buildDomain(mapper.getPriceEntity1())));
 
     Mono<Price> result = getPriceUseCase.getPriceProduct(PRODUCT_ID, BRAND, date);
 
@@ -46,7 +45,7 @@ class GetPriceUseCaseTest {
         .expectNextCount(1)
         .verifyComplete();
 
-    verify(priceRepository).getPricesByDate(PRODUCT_ID, BRAND, date);
+    verify(priceRepository).findApplicablePrices(PRODUCT_ID, BRAND, date);
   }
 
   @Test
@@ -55,8 +54,8 @@ class GetPriceUseCaseTest {
 
     LocalDateTime date = LocalDateTime.of(2020, 6, 14, 16, 0, 0);
 
-    when(priceRepository.getPricesByDate(PRODUCT_ID, BRAND, date))
-        .thenReturn(Flux.fromIterable(mapper.getPricesByDate()));
+    when(priceRepository.findApplicablePrices(PRODUCT_ID, BRAND, date))
+        .thenReturn(Mono.just(mapper.buildDomain(mapper.getPriceEntity1())));
 
     Mono<Price> result = getPriceUseCase.getPriceProduct(PRODUCT_ID, BRAND, date);
 
@@ -64,7 +63,7 @@ class GetPriceUseCaseTest {
         .expectNextCount(1)
         .verifyComplete();
 
-    verify(priceRepository).getPricesByDate(PRODUCT_ID, BRAND, date);
+    verify(priceRepository).findApplicablePrices(PRODUCT_ID, BRAND, date);
   }
 
   @Test
@@ -73,8 +72,8 @@ class GetPriceUseCaseTest {
 
     LocalDateTime date = LocalDateTime.of(2020, 6, 14, 21, 0, 0);
 
-    when(priceRepository.getPricesByDate(PRODUCT_ID, BRAND, date))
-        .thenReturn(Flux.fromIterable(mapper.getPricesByDate()));
+    when(priceRepository.findApplicablePrices(PRODUCT_ID, BRAND, date))
+        .thenReturn(Mono.just(mapper.buildDomain(mapper.getPriceEntity1())));
 
     Mono<Price> result = getPriceUseCase.getPriceProduct(PRODUCT_ID, BRAND, date);
 
@@ -82,7 +81,7 @@ class GetPriceUseCaseTest {
         .expectNextCount(1)
         .verifyComplete();
 
-    verify(priceRepository).getPricesByDate(PRODUCT_ID, BRAND, date);
+    verify(priceRepository).findApplicablePrices(PRODUCT_ID, BRAND, date);
   }
 
   @Test
@@ -91,8 +90,8 @@ class GetPriceUseCaseTest {
 
     LocalDateTime date = LocalDateTime.of(2020, 6, 15, 10, 0, 0);
 
-    when(priceRepository.getPricesByDate(PRODUCT_ID, 1, date))
-        .thenReturn(Flux.fromIterable(mapper.getPricesByDate()));
+    when(priceRepository.findApplicablePrices(PRODUCT_ID, 1, date))
+        .thenReturn(Mono.just(mapper.buildDomain(mapper.getPriceEntity1())));
 
     Mono<Price> result = getPriceUseCase.getPriceProduct(PRODUCT_ID, 1, date);
 
@@ -100,7 +99,7 @@ class GetPriceUseCaseTest {
         .expectNextCount(1)
         .verifyComplete();
 
-    verify(priceRepository).getPricesByDate(PRODUCT_ID, 1, date);
+    verify(priceRepository).findApplicablePrices(PRODUCT_ID, 1, date);
   }
 
   @Test
@@ -109,8 +108,8 @@ class GetPriceUseCaseTest {
 
     LocalDateTime date = LocalDateTime.of(2020, 6, 16, 21, 0, 0);
 
-    when(priceRepository.getPricesByDate(PRODUCT_ID, 1, date))
-        .thenReturn(Flux.fromIterable(mapper.getPricesByDate()));
+    when(priceRepository.findApplicablePrices(PRODUCT_ID, 1, date))
+        .thenReturn(Mono.just(mapper.buildDomain(mapper.getPriceEntity1())));
 
     Mono<Price> result = getPriceUseCase.getPriceProduct(PRODUCT_ID, 1, date);
 
@@ -118,6 +117,6 @@ class GetPriceUseCaseTest {
         .expectNextCount(1)
         .verifyComplete();
 
-    verify(priceRepository).getPricesByDate(PRODUCT_ID, 1, date);
+    verify(priceRepository).findApplicablePrices(PRODUCT_ID, 1, date);
   }
 }

--- a/src/test/java/com/ecommerce/pricing/domain/apater/PriceRepositoryAdapterTest.java
+++ b/src/test/java/com/ecommerce/pricing/domain/apater/PriceRepositoryAdapterTest.java
@@ -47,7 +47,7 @@ class PriceRepositoryAdapterTest {
     when(priceRepository.findPrecesByProductId(productId))
         .thenReturn(mapper.getListPricesByProduct());
 
-    Flux<Price> result = adapter.getAllPricesByProductId(productId);
+    Flux<Price> result = adapter.findAllPricesByProductId(productId);
 
     StepVerifier.create(result)
         .expectNextCount(4).verifyComplete();
@@ -59,10 +59,10 @@ class PriceRepositoryAdapterTest {
   @DisplayName("Get the price of the product by id")
   void getPriceById() {
 
-    when(priceRepository.findById(1L))
-        .thenReturn(Optional.of(mapper.getPriceEntity1()));
+    when(priceRepository.findPriceById(1L))
+        .thenReturn(mapper.getPriceEntity1());
 
-    Mono<Price> result = adapter.getPriceById(1L);
+    Mono<Price> result = adapter.findPriceById(1L);
 
     StepVerifier.create(result)
         .assertNext(price -> {
@@ -76,7 +76,7 @@ class PriceRepositoryAdapterTest {
         })
         .verifyComplete();
 
-    verify(priceRepository).findById(1L);
+    verify(priceRepository).findPriceById(1L);
   }
 
   @Test
@@ -86,7 +86,7 @@ class PriceRepositoryAdapterTest {
     when(priceRepository.findApplicablePrice(productId, 1, date))
         .thenReturn(mapper.getPriceEntity1());
 
-    Flux<Price> result = adapter.getPricesByDate(productId, 1, date);
+    Mono<Price> result = adapter.findApplicablePrices(productId, 1, date);
 
     StepVerifier.create(result)
         .assertNext(price -> {


### PR DESCRIPTION
* Renamed `getPricesByDate(...)` to `findApplicablePrice(...)` to better express business intent
* Renamed `getPriceById(...)` to `findById(...)`
* Renamed `getAllPricesByProductId(...)` to `findAllByProductId(...)`
* Updated all references across use cases, adapters, and tests
* Renamed `GetAllPriceForProductUseCase` to `GetAllPricesByProductIdUseCase`
* Renamed `GetPriceForIdentifierUseCase` to `GetPriceByIdUseCase
* Renamed `GetPriceUseCase` to `GetApplicablePriceUseCase
